### PR TITLE
Fix blurry setup scanner

### DIFF
--- a/pretixscan/app/src/main/res/layout/activity_setup.xml
+++ b/pretixscan/app/src/main/res/layout/activity_setup.xml
@@ -22,10 +22,7 @@
             <eu.pretix.pretixscan.droid.ui.ScannerView
                 android:id="@+id/scanner_view"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_marginTop="16dp" >
-
-            </eu.pretix.pretixscan.droid.ui.ScannerView>
+                android:layout_height="match_parent" />
 
             <LinearLayout
                 android:id="@+id/llHardwareScan"


### PR DESCRIPTION
![Screenshot_20210122_132409_eu.pretix.pretixscan.droid.debug.jpg](https://user-images.githubusercontent.com/654548/105490731-811e1380-5cb5-11eb-8d3f-098b6c2eac87.jpg)![Screenshot_20210122_132449_eu.pretix.pretixscan.droid.debug.jpg](https://user-images.githubusercontent.com/654548/105490738-83806d80-5cb5-11eb-82bb-5c9d0d712797.jpg)

OK, great, both screenshots are blurry, because I have to push buttons for the screenshot to happen... But I hope that it is visible that the top screenshot is even blurrier...

In fact, it seems to be so blurry, that my Huawei P30 Pro cannot scan any setup barcodes at all..

Third attempt:
![Screenshot_20210122_132927_eu.pretix.pretixscan.droid.debug.jpg](https://user-images.githubusercontent.com/654548/105490984-e83bc800-5cb5-11eb-9b2f-b13f57590bf1.jpg)