### PR TITLE
Add custom user-agent header with pretixSCAN version

### DIFF
--- a/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/AndroidHttpClientFactory.kt
+++ b/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/AndroidHttpClientFactory.kt
@@ -1,7 +1,5 @@
 package eu.pretix.pretixscan.droid
 
-import android.app.Application
-import android.content.Context
 import eu.pretix.libpretixsync.api.HttpClientFactory
 import eu.pretix.libpretixsync.api.RateLimitInterceptor
 import okhttp3.OkHttpClient
@@ -15,6 +13,7 @@ import javax.security.cert.CertificateException
 class AndroidHttpClientFactory(val app: PretixScan) : HttpClientFactory {
     override fun buildClient(ignore_ssl: Boolean): OkHttpClient {
         val builder = OkHttpClient.Builder()
+        builder.addNetworkInterceptor(AndroidUserAgentInterceptor())
 
         if (app.flipperInit?.interceptor != null) {
             builder.addNetworkInterceptor(app.flipperInit!!.interceptor!!)

--- a/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/AndroidUserAgentInterceptor.kt
+++ b/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/AndroidUserAgentInterceptor.kt
@@ -1,0 +1,17 @@
+package eu.pretix.pretixscan.droid
+
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+
+class AndroidUserAgentInterceptor : Interceptor {
+    private val ua = "${okhttp3.internal.userAgent} ${BuildConfig.APPLICATION_ID}/${BuildConfig.VERSION_NAME}"
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val req: Request = chain.request()
+        val uaReq: Request = req.newBuilder()
+            .header("User-Agent", ua)
+            .build()
+        return chain.proceed(uaReq)
+    }
+}


### PR DESCRIPTION
Adds custom user-agent header with the compiled pretixSCAN version to every outgoing request.
Example: `User-Agent: okhttp/4.9.3 pretixSCAN/1.15.0-debug`

If that looks okay, I'll go and add similar code to all our other android projects.