### PR TITLE
Add debouncing mechanism for hardware scanner

### DIFF
--- a/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/MainActivity.kt
+++ b/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/MainActivity.kt
@@ -171,6 +171,9 @@ class MainActivity : AppCompatActivity(), ReloadableActivity, ZXingScannerView.R
 
     private val hardwareScanner = HardwareScanner(object : ScanReceiver {
         override fun scanResult(result: String) {
+            if (result == lastScanCode && System.currentTimeMillis() - lastScanTime < 2500) {
+                return
+            }
             lastScanTime = System.currentTimeMillis()
             lastScanCode = result
             lastIgnoreUnpaid = false


### PR DESCRIPTION
This adds a debouncing mechanism for double-scans for hardware scanners as well. I have opted for half the timeout of the camera scan debounding for purely feeling-based reasons when playing around with the devices. Not sure if this holds up universally but it also feels to unimportant to make it a setting, rather iterate based on user feedback.