### PR TITLE
Skip scan result if question dialog is showing (Z#23133056)

### DIFF
--- a/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/MainActivity.kt
+++ b/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/MainActivity.kt
@@ -895,6 +895,13 @@ class MainActivity : AppCompatActivity(), ReloadableActivity, ZXingScannerView.R
             return
         }
 
+        if (dialog?.isShowing() == true) {
+            /*
+             * Skip scan if a dialog is still in front. This forces users to answer the questions asked.
+             */
+            return
+        }
+
         val result = if (Regex("^HC1:[0-9A-Z $%*+-./:]+$").matches(raw_result.toUpperCase(Locale.getDefault()))) {
             /*
              * This is a bit of a hack. pretixSCAN 1.11+ supports checking digital COVID vaccination


### PR DESCRIPTION
A customer reported that scanning tickets while a question dialog is open stacks the dialogs, which is very confusing.
This PR just skips new scan results until the question dialog is gone.

This may be confusing if the scanning hardware itself makes a sound on sucessfully recognized code, but this may be an issue we have already anyway.