### PR TITLE
Add support for different scan engines

### DIFF
--- a/pretixscan/app/build.gradle
+++ b/pretixscan/app/build.gradle
@@ -174,6 +174,9 @@ dependencies {
     }
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.github.apg-mobile:android-round-textview:v1.0.0'
+
+    implementation "com.google.android.gms:play-services-base:18.7.2"
+    implementation "com.google.android.gms:play-services-mlkit-barcode-scanning:18.3.1"
 }
 
 sqldelight {

--- a/pretixscan/app/src/main/AndroidManifest.xml
+++ b/pretixscan/app/src/main/AndroidManifest.xml
@@ -112,6 +112,10 @@
                 android:resource="@xml/filepaths" />
         </provider>
 
+        <meta-data
+            android:name="com.google.mlkit.vision.DEPENDENCIES"
+            android:value="barcode" />
+
         <meta-data android:name="io.sentry.dsn" android:value="${SENTRY_DSN}" />
         <meta-data android:name="io.sentry.attach-screenshot" android:value="false" />
         <meta-data android:name="io.sentry.attach-view-hierarchy" android:value="false" />

--- a/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/AppConfig.kt
+++ b/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/AppConfig.kt
@@ -66,6 +66,12 @@ class AppConfig(ctx: Context) : ConfigStore {
                 .putString(PREFS_KEY_AUTOPRINTBADGES, "once")
                 .commit()
         }
+        if (prefs.contains(LEGACY_PREFS_KEY_USE_CAMERA)) {
+            prefs.edit()
+                .putString(PREFS_KEY_SCAN_ENGINE, if (prefs.getBoolean(LEGACY_PREFS_KEY_USE_CAMERA, true)) "zxing" else "hardware")
+                .remove(LEGACY_PREFS_KEY_USE_CAMERA)
+                .commit()
+        }
     }
 
     override fun isDebug(): Boolean {
@@ -339,9 +345,9 @@ class AppConfig(ctx: Context) : ConfigStore {
             }
         }
 
-    var useCamera: Boolean
-        get() = default_prefs.getBoolean(PREFS_KEY_USE_CAMERA, true)
-        set(value) = default_prefs.edit().putBoolean(PREFS_KEY_USE_CAMERA, value).apply()
+    @Deprecated("use scanEngine instead")
+    val useCamera: Boolean
+        get() = default_prefs.getString(PREFS_KEY_SCAN_ENGINE, "zxing") != "hardware"
 
     val hideNames: Boolean
         get() = default_prefs.getBoolean(PREFS_KEY_HIDE_NAMES, false)
@@ -397,6 +403,10 @@ class AppConfig(ctx: Context) : ConfigStore {
         get() = default_prefs.getBoolean(PREFS_KEY_SYNC_ORDERS, true)
         set(value) = default_prefs.edit().putBoolean(PREFS_KEY_SYNC_ORDERS, value).apply()
 
+    var scanEngine: String
+        get() = default_prefs.getString(PREFS_KEY_SCAN_ENGINE, "zxing") ?: "zxing"
+        set(value) = default_prefs.edit().putString(PREFS_KEY_SCAN_ENGINE, value).apply()
+
     override fun getKnownLiveEventSlugs(): Set<String> {
         return default_prefs.getStringSet(PREFS_KEY_KNOWN_LIVE_EVENT_SLUGS, emptySet()) as Set<String>
     }
@@ -435,7 +445,7 @@ class AppConfig(ctx: Context) : ConfigStore {
         val PREFS_KEY_SCAN_FLASH = "scan_flash"
         val PREFS_KEY_SYNC_ORDERS = "pref_sync_orders"
         val PREFS_KEY_AUTO_SWITCH = "pref_auto_switch"
-        val PREFS_KEY_USE_CAMERA = "pref_use_camera"
+        val LEGACY_PREFS_KEY_USE_CAMERA = "pref_use_camera"
         val PREFS_KEY_SCAN_OFFLINE = "pref_scan_offline"
         val PREFS_KEY_SCAN_OFFLINE_AUTO = "pref_auto_offline"
         val PREFS_KEY_SCAN_PROXY = "pref_scan_proxy"
@@ -451,6 +461,7 @@ class AppConfig(ctx: Context) : ConfigStore {
         val PREFS_KEY_SEARCH_DISABLE = "pref_search_disable"
         val PREFS_KEY_KIOSK_MODE = "pref_kiosk_mode"
         val PREFS_KEY_MULTI_EVENT_MODE = "multi_event_mode"
+        val PREFS_KEY_SCAN_ENGINE = "pref_scan_engine"
         private const val PREFS_KEY_KNOWN_LIVE_EVENT_SLUGS = "cache_known_live_event_slugs"
     }
 }

--- a/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/Settings.kt
+++ b/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/Settings.kt
@@ -175,6 +175,10 @@ class SettingsFragment : PreferenceFragmentCompat() {
                 true
             }
         }
+
+        // FIXME: pref_scan_engine. if BuildConfig.FLAVOR_edition == "foss", don't offer mlkit (disable?)
+        // FIXME: pref_scan_engine. check installation status of mlkit and warn for potential large download
+        // FIXME: pref_scan_engine. if changed to mlkit, check installation status
     }
 
     private fun asset_dialog(@RawRes htmlRes: Int, @StringRes title: Int) {

--- a/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/SetupActivity.kt
+++ b/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/SetupActivity.kt
@@ -83,7 +83,7 @@ class SetupActivity : AppCompatActivity(), SetupCallable {
 
     override fun config(useCamera: Boolean) {
         val conf = AppConfig(this)
-        conf.useCamera = useCamera
+        conf.scanEngine = if (useCamera) "zxing" else "hardware"
     }
 
     override fun setup(url: String, token: String) {

--- a/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/WelcomeActivity.kt
+++ b/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/WelcomeActivity.kt
@@ -59,7 +59,7 @@ class WelcomeActivity : AppCompatActivity() {
 
         if (defaultToScanner()) {
             val conf = AppConfig(this)
-            conf.useCamera = false
+            conf.scanEngine = "hardware"
         }
     }
 

--- a/pretixscan/app/src/main/res/values/arrays.xml
+++ b/pretixscan/app/src/main/res/values/arrays.xml
@@ -16,4 +16,9 @@
         <item>once</item>
         <item>true</item>
     </string-array>
+    <string-array name="settings_values_scan_engine">
+        <item>zxing</item>
+        <item>mlkit</item>
+        <item>hardware</item>
+    </string-array>
 </resources>

--- a/pretixscan/app/src/main/res/values/strings.xml
+++ b/pretixscan/app/src/main/res/values/strings.xml
@@ -135,6 +135,7 @@
     <string name="preference_badgeprint_enable">Enable badge printing</string>
     <string name="preference_autobadgeprint_enable">Print badges automatically</string>
     <string name="preference_badgeprint_install_pretixprint">Printing badges requires the separate pretixPRINT app. Do you want to install it?</string>
+    <string name="preference_scan_engine">Barcode scanner to use</string>
     <string name="already_scanned">already scanned</string>
     <string name="total_tickets_sold">total tickets sold</string>
     <string name="ticket_attention">Attention, special ticket!</string>
@@ -168,6 +169,11 @@
         <item>No, only when button is pressed</item>
         <item>Once, if not yet printed</item>
         <item>Always</item>
+    </string-array>
+    <string-array name="settings_valuelabels_scan_engine">
+        <item>Zebra Crossing (ZXing)</item>
+        <item>Google ML Kit</item>
+        <item>Hardware scanner of this device</item>
     </string-array>
     <string name="headline_please_reinstall">Please reinstall pretixSCAN</string>
     <string name="reinstall_text">Your previous pretixSCAN version was too old and your local data cannot be used for the current version.\n\nPlease clear the storage for the pretixSCAN app or delete and reinstall the app.</string>

--- a/pretixscan/app/src/main/res/xml/app_restrictions.xml
+++ b/pretixscan/app/src/main/res/xml/app_restrictions.xml
@@ -5,6 +5,7 @@
         android:key="pref_sync_auto"
         android:restrictionType="bool"
         android:title="@string/settings_label_auto_sync" />
+    <!-- FIXME, remove/migrate? -->
     <restriction
         android:defaultValue="true"
         android:key="pref_use_camera"

--- a/pretixscan/app/src/main/res/xml/preferences.xml
+++ b/pretixscan/app/src/main/res/xml/preferences.xml
@@ -32,10 +32,13 @@
             android:title="@string/settings_label_auto_switch" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/settings_label_ui">
-        <CheckBoxPreference
-            android:defaultValue="true"
-            android:key="pref_use_camera"
-            android:title="@string/settings_label_device_camera" />
+        <ListPreference
+            android:key="pref_scan_engine"
+            android:defaultValue="zxing"
+            android:entries="@array/settings_valuelabels_scan_engine"
+            android:entryValues="@array/settings_values_scan_engine"
+            android:title="@string/preference_scan_engine"
+            android:summary="%s" />
         <CheckBoxPreference
             android:defaultValue="true"
             android:key="pref_sounds"


### PR DESCRIPTION
This allows us to switch between hardware scanner, built-in zxing and on-demand Google ML Kit Barcode Scanning.

TODO:
- [ ] add build flavor dimension `edition`, so we can build/release a FOSS-only apk without ml-kit/playservices-dependency (👀 fdroid)
- [ ] warn for potential large download happening when scan engine is switched to mlkit and it's not installed yet
- [ ] add some debug indicator showing us which scan engine is used