### PR TITLE
Implemented deep link support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ Security
 
 If you discover a security issue, please contact us at security@pretix.eu and see our [Responsible Disclosure Policy](https://docs.pretix.eu/trust/security/disclosure/) further information.
 
+Setup Links
+-----------
+
+pretixSCAN can be opened directly for initial device setup through a custom deep link:
+
+`pretixscan://setup?url=https%3A%2F%2Fexample.test&token=YOUR_DEVICE_TOKEN`
+
 License
 -------
 The code in this repository is published under the terms of the Apache License. 

--- a/pretixscan/app/src/main/AndroidManifest.xml
+++ b/pretixscan/app/src/main/AndroidManifest.xml
@@ -70,8 +70,20 @@
             android:theme="@style/AppTheme.NoActionBar.Dark" />
         <activity
             android:name=".ui.SetupActivity"
+            android:exported="true"
             android:label="@string/headline_setup"
-            android:theme="@style/AppTheme.NoActionBar.Dark" />
+            android:theme="@style/AppTheme.NoActionBar.Dark">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="pretixscan"
+                    android:host="setup" />
+            </intent-filter>
+        </activity>
         <activity
             android:name=".ui.info.EventinfoActivity"
             android:label="@string/action_label_statistics"

--- a/pretixscan/app/src/main/AndroidManifest.xml
+++ b/pretixscan/app/src/main/AndroidManifest.xml
@@ -66,10 +66,6 @@
         </activity>
         <activity
             android:name=".ui.WelcomeActivity"
-            android:label="@string/headline_setup"
-            android:theme="@style/AppTheme.NoActionBar.Dark" />
-        <activity
-            android:name=".ui.SetupActivity"
             android:exported="true"
             android:label="@string/headline_setup"
             android:theme="@style/AppTheme.NoActionBar.Dark">
@@ -84,6 +80,10 @@
                     android:host="setup" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".ui.SetupActivity"
+            android:label="@string/headline_setup"
+            android:theme="@style/AppTheme.NoActionBar.Dark" />
         <activity
             android:name=".ui.info.EventinfoActivity"
             android:label="@string/action_label_statistics"

--- a/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/SetupActivity.kt
+++ b/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/SetupActivity.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.view.KeyEvent
+import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.os.bundleOf
@@ -170,7 +171,7 @@ class SetupActivity : AppCompatActivity(), SetupCallable {
             return
         }
         if (AppConfig(this).deviceRegistered) {
-            showSetupAlert(R.string.setup_error_already_configured)
+            resumeScanningWithAlreadyConfiguredWarning()
             return
         }
         importSetupLink(url, token)
@@ -196,7 +197,11 @@ class SetupActivity : AppCompatActivity(), SetupCallable {
             } catch (e: Exception) {
                 handleSetupException(e)
             } finally {
-                pdialog.dismiss()
+                if (pdialog.isShowing) {
+                    runCatching {
+                        pdialog.dismiss()
+                    }
+                }
             }
         }
     }
@@ -228,5 +233,14 @@ class SetupActivity : AppCompatActivity(), SetupCallable {
             .setMessage(message)
             .setPositiveButton(R.string.ok, null)
             .show()
+    }
+
+    private fun resumeScanningWithAlreadyConfiguredWarning() {
+        Toast.makeText(applicationContext, R.string.setup_error_already_configured, Toast.LENGTH_LONG).show()
+        val mainIntent = Intent(this, MainActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+        }
+        startActivity(mainIntent)
+        finish()
     }
 }

--- a/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/SetupActivity.kt
+++ b/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/SetupActivity.kt
@@ -1,6 +1,8 @@
 package eu.pretix.pretixscan.droid.ui
 
+import android.app.ProgressDialog
 import android.content.Intent
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.view.KeyEvent
@@ -12,17 +14,28 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
 import androidx.fragment.app.commit
 import androidx.fragment.app.replace
+import androidx.lifecycle.lifecycleScope
+import eu.pretix.libpretixsync.setup.SetupBadRequestException
+import eu.pretix.libpretixsync.setup.SetupBadResponseException
+import eu.pretix.libpretixsync.setup.SetupException
 import eu.pretix.libpretixsync.setup.SetupManager
+import eu.pretix.libpretixsync.setup.SetupServerErrorException
+import eu.pretix.libpretixui.android.scanning.defaultToScanner
 import eu.pretix.libpretixui.android.setup.SetupCallable
 import eu.pretix.libpretixui.android.setup.SetupFragment
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import eu.pretix.pretixscan.droid.AndroidHttpClientFactory
 import eu.pretix.pretixscan.droid.AppConfig
 import eu.pretix.pretixscan.droid.BuildConfig
 import eu.pretix.pretixscan.droid.PretixScan
 import eu.pretix.pretixscan.droid.R
 import io.sentry.Sentry
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.IOException
 import java.lang.Exception
+import javax.net.ssl.SSLException
 
 class SetupActivity : AppCompatActivity(), SetupCallable {
     companion object {
@@ -55,13 +68,8 @@ class SetupActivity : AppCompatActivity(), SetupCallable {
         }
 
         if (savedInstanceState == null) {
-            val args = bundleOf(
-                SetupFragment.ARG_DEFAULT_HOST to if (BuildConfig.APPLICATION_ID.contains("eu.pretix")) "https://pretix.eu" else ""
-            )
-            supportFragmentManager.commit {
-                setReorderingAllowed(true)
-                replace<SetupFragment>(R.id.content, FRAGMENT_TAG, args)
-            }
+            ensureSetupFragment()
+            handleSetupLink(intent.data)
         }
 
         if (dataWedgeHelper.isInstalled) {
@@ -131,5 +139,94 @@ class SetupActivity : AppCompatActivity(), SetupCallable {
 
     override fun onGenericSetupException(e: Exception) {
         Sentry.captureException(e)
+    }
+
+    private fun ensureSetupFragment() {
+        if (supportFragmentManager.findFragmentByTag(FRAGMENT_TAG) != null) {
+            return
+        }
+        val args = bundleOf(
+            SetupFragment.ARG_DEFAULT_HOST to if (BuildConfig.APPLICATION_ID.contains("eu.pretix")) "https://pretix.eu" else ""
+        )
+        supportFragmentManager.commit {
+            setReorderingAllowed(true)
+            replace<SetupFragment>(R.id.content, FRAGMENT_TAG, args)
+        }
+    }
+
+    private fun handleSetupLink(uri: Uri?) {
+        if (uri?.scheme?.equals("pretixscan", ignoreCase = true) != true) {
+            return
+        }
+        if (uri.host?.equals("setup", ignoreCase = true) != true) {
+            return
+        }
+
+        val url = uri.getQueryParameter("url")?.trim()
+        val token = uri.getQueryParameter("token")?.trim()
+
+        if (url.isNullOrBlank() || token.isNullOrBlank()) {
+            showSetupAlert(R.string.setup_error_invalid_link)
+            return
+        }
+        if (AppConfig(this).deviceRegistered) {
+            showSetupAlert(R.string.setup_error_already_configured)
+            return
+        }
+        importSetupLink(url, token)
+    }
+
+    private fun importSetupLink(url: String, token: String) {
+        val pdialog = ProgressDialog(this).apply {
+            isIndeterminate = true
+            setMessage(getString(R.string.progress_registering))
+            setTitle(R.string.progress_registering)
+            setCanceledOnTouchOutside(false)
+            setCancelable(false)
+            show()
+        }
+
+        lifecycleScope.launch {
+            try {
+                withContext(Dispatchers.IO) {
+                    setup(url, token)
+                }
+                config(!defaultToScanner())
+                onSuccessfulSetup()
+            } catch (e: Exception) {
+                handleSetupException(e)
+            } finally {
+                pdialog.dismiss()
+            }
+        }
+    }
+
+    private fun handleSetupException(e: Exception) {
+        when (e) {
+            is SetupBadRequestException -> showSetupAlert(e.message ?: getString(R.string.setup_error_invalid_link))
+            is SSLException -> showSetupAlert(R.string.setup_error_ssl)
+            is IOException -> showSetupAlert(R.string.setup_error_io)
+            is SetupServerErrorException -> showSetupAlert(R.string.setup_error_server)
+            is SetupBadResponseException -> showSetupAlert(R.string.setup_error_response)
+            is SetupException -> showSetupAlert(e.message ?: getString(R.string.error_unknown_exception))
+            else -> {
+                onGenericSetupException(e)
+                showSetupAlert(e.message ?: getString(R.string.error_unknown_exception))
+            }
+        }
+    }
+
+    private fun showSetupAlert(messageRes: Int) {
+        showSetupAlert(getString(messageRes))
+    }
+
+    private fun showSetupAlert(message: CharSequence) {
+        if (isFinishing || isDestroyed) {
+            return
+        }
+        MaterialAlertDialogBuilder(this)
+            .setMessage(message)
+            .setPositiveButton(R.string.ok, null)
+            .show()
     }
 }

--- a/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/WelcomeActivity.kt
+++ b/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/WelcomeActivity.kt
@@ -27,6 +27,12 @@ class WelcomeActivity : AppCompatActivity() {
     public override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
+
+        if (isSetupDeepLink() && AppConfig(this).deviceRegistered) {
+            resumeScanningWithAlreadyConfiguredWarning()
+            return
+        }
+
         val binding = DataBindingUtil.setContentView<ActivityWelcomeBinding>(this, R.layout.activity_welcome)
         setContentView(binding.root)
         setSupportActionBar(binding.topAppBar)
@@ -49,9 +55,7 @@ class WelcomeActivity : AppCompatActivity() {
 
         binding.button?.setOnClickListener {
             if (ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED) {
-                val intent = Intent(this, SetupActivity::class.java)
-                startActivity(intent)
-                finish()
+                startSetupActivity()
             } else {
                 checkPermission(Manifest.permission.CAMERA, PERMISSIONS_REQUEST_CAMERA)
             }
@@ -68,9 +72,7 @@ class WelcomeActivity : AppCompatActivity() {
         when (requestCode) {
             PERMISSIONS_REQUEST_CAMERA -> {
                 if ((grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED)) {
-                    val intent = Intent(this, SetupActivity::class.java)
-                    startActivity(intent)
-                    finish()
+                    startSetupActivity()
                 } else {
                     Toast.makeText(this, "Please grant camera permission to use the QR Scanner", Toast.LENGTH_SHORT).show();
                 }
@@ -80,5 +82,28 @@ class WelcomeActivity : AppCompatActivity() {
                 super.onRequestPermissionsResult(requestCode, permissions, grantResults)
             }
         }
+    }
+
+    private fun startSetupActivity() {
+        val setupIntent = Intent(this, SetupActivity::class.java).apply {
+            data = intent?.data
+        }
+        startActivity(setupIntent)
+        finish()
+    }
+
+    private fun resumeScanningWithAlreadyConfiguredWarning() {
+        Toast.makeText(applicationContext, R.string.setup_error_already_configured, Toast.LENGTH_LONG).show()
+        val mainIntent = Intent(this, MainActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+        }
+        startActivity(mainIntent)
+        finish()
+    }
+
+    private fun isSetupDeepLink(): Boolean {
+        val uri = intent?.data ?: return false
+        return uri.scheme.equals("pretixscan", ignoreCase = true) &&
+                uri.host.equals("setup", ignoreCase = true)
     }
 }

--- a/pretixscan/app/src/main/res/values/strings.xml
+++ b/pretixscan/app/src/main/res/values/strings.xml
@@ -7,8 +7,8 @@
     <string name="progress_syncing">Synchronizing with server…</string>
     <string name="progress_processing">Processing…</string>
     <string name="progress_registering">Registering device with server…</string>
-    <string name="setup_error_invalid_link">The setup link is invalid. Please ask your pretix administrator for a new link.</string>
-    <string name="setup_error_already_configured">This device is already configured. To use a setup link, first delete all local data and reset the device in the app settings.</string>
+    <string name="setup_error_invalid_link">The setup link is invalid.</string>
+    <string name="setup_error_already_configured">This device is already configured. Reset the app to use a setup link.</string>
     <string name="error_access_revoked">Device access has been revoked, you need to register the device with the server again.</string>
     <string name="error_unknown_exception">An unknown error has occurred</string>
     <string name="error_exception">An error has occurred</string>

--- a/pretixscan/app/src/main/res/values/strings.xml
+++ b/pretixscan/app/src/main/res/values/strings.xml
@@ -7,6 +7,8 @@
     <string name="progress_syncing">Synchronizing with server…</string>
     <string name="progress_processing">Processing…</string>
     <string name="progress_registering">Registering device with server…</string>
+    <string name="setup_error_invalid_link">The setup link is invalid. Please ask your pretix administrator for a new link.</string>
+    <string name="setup_error_already_configured">This device is already configured. To use a setup link, first delete all local data and reset the device in the app settings.</string>
     <string name="error_access_revoked">Device access has been revoked, you need to register the device with the server again.</string>
     <string name="error_unknown_exception">An unknown error has occurred</string>
     <string name="error_exception">An error has occurred</string>


### PR DESCRIPTION
Added pretixscan://setup deep-link support so device setup can start from an “Open in pretixSCAN” link (or deeplink-enabled QR) instead of only QR scanning or manual token entry. This is potentially useful for events with 20+ volunteers scanning tickets at once during rush hour, focusing on easy onboarding.

Registered URL scheme:

```pretixscan://setup?url=https%3A%2F%2Fpretix.eu&token=DEVICE_TOKEN```

If the device has already been set up then the app displays an error instructing the user to reset their settings first before attempting to tap on the link again.