### PR TITLE
Fix missing entry/exit icons in hardware scanning mode (Z#23238678)

### DIFF
--- a/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/BaseScanActivity.kt
+++ b/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/BaseScanActivity.kt
@@ -196,6 +196,8 @@ abstract class BaseScanActivity : AppCompatActivity(), ReloadableActivity, Scann
     }
 
     public override fun onCreate(savedInstanceState: Bundle?) {
+        // NOTE: binding initialization happens in the child class *after* this function
+        // make sure you don't depend on it here or in the functions called here
         super.onCreate(savedInstanceState)
         conf = AppConfig(this)
 

--- a/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/MainActivity.kt
+++ b/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/MainActivity.kt
@@ -386,7 +386,7 @@ class MainActivity : BaseScanActivity() {
 
     override fun selectEvent() {
         val intent = Intent(this, EventConfigActivity::class.java)
-        if (binding.mainToolbar.event != null && ViewCompat.isLaidOut(binding.mainToolbar.event)) {
+        if (this::binding.isInitialized && binding.mainToolbar.event != null && ViewCompat.isLaidOut(binding.mainToolbar.event)) {
             val options = ActivityOptionsCompat.makeSceneTransitionAnimation(
                     this@MainActivity, binding.mainToolbar.event, "morph_transition")
             startWithPIN(intent, "switch_event", REQ_EVENT, options.toBundle())

--- a/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/MainActivity.kt
+++ b/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/MainActivity.kt
@@ -245,6 +245,8 @@ class MainActivity : BaseScanActivity() {
     }
 
     override fun reloadSyncStatus() {
+        if (!this::binding.isInitialized) return
+
         if (conf.lastFailedSync > conf.lastSync || System.currentTimeMillis() - conf.lastDownload > 5 * 60 * 1000) {
             binding.textViewStatus.setTextColor(ContextCompat.getColor(this, R.color.pretix_brand_red))
         } else {
@@ -314,8 +316,8 @@ class MainActivity : BaseScanActivity() {
 
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        binding = DataBindingUtil.setContentView(this, R.layout.activity_main)
         super.onCreate(savedInstanceState)
+        binding = DataBindingUtil.setContentView(this, R.layout.activity_main)
 
         view_data.resultState.set(EMPTY)
         view_data.scanType.set(conf.scanType)
@@ -372,10 +374,12 @@ class MainActivity : BaseScanActivity() {
     }
 
     override fun setupApi() {
-        val ebt = eventButtonText()
-        if (binding.mainToolbar.event != null && binding.mainToolbar.event.text != ebt) {  // can be null if search bar is open
-            binding.mainToolbar.event.text = ebt
-            (binding.mainToolbar.event.parent as View?)?.forceLayout()
+        if (this::binding.isInitialized) {
+            val ebt = eventButtonText()
+            if (binding.mainToolbar.event != null && binding.mainToolbar.event.text != ebt) {  // can be null if search bar is open
+                binding.mainToolbar.event.text = ebt
+                (binding.mainToolbar.event.parent as View?)?.forceLayout()
+            }
         }
         super.setupApi()
     }


### PR DESCRIPTION
This happens because `app:srcCompat` in the view xml only works if the view init (here: databinding) is called after onCreate of the parent classes, which includes AppCompatActivity, which provides support for this parameter.

Another option would be to drop `app:srcCompat` and use `android:src`, because we don't support Android < 5 anymore and the androidx.appcompat is not needed for vector drawables anymore.