### PR TITLE
Fix sync being scheduled multiple times on launch

### DIFF
--- a/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/BaseScanActivity.kt
+++ b/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/BaseScanActivity.kt
@@ -210,21 +210,10 @@ abstract class BaseScanActivity : AppCompatActivity(), ReloadableActivity, Scann
             registerDevice()
             return
         }
-        try {
-            setupApi()
-        } catch (e: IllegalStateException) {
-            // IllegalStateException is thrown by db access -> Migrations.minVersionCallback
-            Sentry.captureException(e)
-            panicPleaseReinstall()
-            return
-        }
 
         if (conf.synchronizedEvents.isEmpty()) {
             selectEvent()
-        } else if (conf.lastDownload < 1) {
-            syncNow()
         }
-        scheduleSync()
 
         if (dataWedgeHelper.isInstalled) {
             try {
@@ -441,7 +430,11 @@ abstract class BaseScanActivity : AppCompatActivity(), ReloadableActivity, Scann
         }
         getRestrictions(this)
 
-        scheduleSync()
+        if (conf.lastDownload < 1) {
+            syncNow()
+        } else {
+            scheduleSync()
+        }
 
         hardwareScanner.start(this)
         (application as PretixScan).connectivityHelper.addListener(this)

--- a/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/MainActivity.kt
+++ b/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/MainActivity.kt
@@ -449,8 +449,6 @@ class MainActivity : BaseScanActivity() {
             supportActionBar?.show()
         }
 
-        scheduleSync()
-
         LED(this).off()
 
         if (conf.useCamera && ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED) {


### PR DESCRIPTION
In the [lifecycle of `onCreate` → `onResume`](https://developer.android.com/guide/components/activities/activity-lifecycle#activity-lifecycle-concepts) the api and syncmanager were initialized multiple times. 