### PR TITLE
Scan addon display

### DIFF
--- a/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/MainActivity.kt
+++ b/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/MainActivity.kt
@@ -91,6 +91,7 @@ class ViewDataHolder(private val ctx: Context) {
     val isOffline = ObservableField<Boolean>()
     val hideTimerVisible = ObservableField<Boolean>()
     val hideTimerProgress = ObservableField<Int>()
+    val addonTexts = ObservableField<String>()
 
     fun getColor(state: ResultState): Int {
         return ctx.resources.getColor(when (state) {
@@ -527,6 +528,7 @@ class MainActivity : BaseScanActivity() {
         view_data.reasonExplanation.set(null)
         view_data.questionAndAnswers.set(null)
         view_data.checkInTexts.set(null)
+        view_data.addonTexts.set(null)
         view_data.firstScanned.set(null)
         view_data.attention.set(false)
         if (card_state == ResultCardState.HIDDEN) {
@@ -811,6 +813,16 @@ class MainActivity : BaseScanActivity() {
             view_data.checkInTexts.set(result.checkinTexts!!.filterNot { it.isBlank() }.joinToString("\n").trim())
         } else {
             view_data.checkInTexts.set(null)
+        }
+
+        if (!result.addons.isNullOrEmpty()) {
+            view_data.addonTexts.set(
+                result.addons!!.joinToString("\n") { addon ->
+                    "+ " + listOfNotNull(addon.itemName, addon.variationName).joinToString(" – ")
+                }
+            )
+        } else {
+            view_data.addonTexts.set(null)
         }
 
         if (result.eventSlug != null && conf.eventSelection.size > 1) {

--- a/pretixscan/app/src/main/res/layout/activity_main.xml
+++ b/pretixscan/app/src/main/res/layout/activity_main.xml
@@ -623,6 +623,7 @@
                                             android:layout_height="wrap_content"
                                             android:layout_marginTop="4dp"
                                             android:ellipsize="end"
+                                            android:maxLines="8"
                                             android:gravity="start"
                                             android:lineSpacingMultiplier="1.1"
                                             android:text="@{data.addonTexts}"

--- a/pretixscan/app/src/main/res/layout/activity_main.xml
+++ b/pretixscan/app/src/main/res/layout/activity_main.xml
@@ -520,7 +520,7 @@
                                     android:layout_height="wrap_content"
                                     android:layout_marginBottom="12dp"
                                     android:background="@color/transparent"
-                                    android:visibility="@{data.attendeeName != null || data.orderCodeAndPositionId != null || data.seat != null || data.questionAndAnswers != null || data.checkInTexts != null ? View.VISIBLE : View.GONE}">
+                                    android:visibility="@{data.attendeeName != null || data.orderCodeAndPositionId != null || data.seat != null || data.questionAndAnswers != null || data.checkInTexts != null || data.addonTexts != null ? View.VISIBLE : View.GONE}">
 
                                     <TextView
                                         android:id="@+id/tvAttendeeName"
@@ -564,7 +564,7 @@
                                         android:layout_marginTop="4dp"
                                         android:layout_marginEnd="16dp"
                                         android:orientation="vertical"
-                                        android:visibility="@{((data.seat != null &amp;&amp; !&quot;null&quot;.equals(data.seat)) || (data.questionAndAnswers != null &amp;&amp; !&quot;null&quot;.equals(data.questionAndAnswers)) || (data.checkInTexts != null &amp;&amp; !&quot;null&quot;.equals(data.checkInTexts))) ? View.VISIBLE : View.GONE}"
+                                        android:visibility="@{((data.seat != null &amp;&amp; !&quot;null&quot;.equals(data.seat)) || (data.questionAndAnswers != null &amp;&amp; !&quot;null&quot;.equals(data.questionAndAnswers)) || (data.checkInTexts != null &amp;&amp; !&quot;null&quot;.equals(data.checkInTexts))  || (data.addonTexts != null &amp;&amp; !&quot;null&quot;.equals(data.addonTexts))) ? View.VISIBLE : View.GONE}"
                                         app:layout_constraintBottom_toBottomOf="parent"
                                         app:layout_constraintEnd_toEndOf="parent"
                                         app:layout_constraintStart_toStartOf="parent"
@@ -606,6 +606,31 @@
                                             android:textSize="@dimen/card_result_test_size_small"
                                             android:visibility="@{data.checkInTexts != null &amp;&amp; !&quot;null&quot;.equals(data.checkInTexts) ? View.VISIBLE : View.GONE}"
                                             tools:text="Order, Item, Variation\nCheck-In Texts" />
+                                        <TextView
+                                            android:id="@+id/tvAddonLabel"
+                                            android:layout_width="match_parent"
+                                            android:layout_height="wrap_content"
+                                            android:layout_marginTop="8dp"
+                                            android:text="@string/addons_label"
+                                            android:textAppearance="@style/TextAppearance.AppCompat.Small"
+                                            android:textColor="@color/text_color"
+                                            android:textSize="@dimen/card_result_test_size_small"
+                                            android:textStyle="bold"
+                                            android:visibility="@{data.addonTexts != null &amp;&amp; !&quot;null&quot;.equals(data.addonTexts) ? View.VISIBLE : View.GONE}" />
+                                        <TextView
+                                            android:id="@+id/tvAddonTexts"
+                                            android:layout_width="match_parent"
+                                            android:layout_height="wrap_content"
+                                            android:layout_marginTop="4dp"
+                                            android:ellipsize="end"
+                                            android:gravity="start"
+                                            android:lineSpacingMultiplier="1.1"
+                                            android:text="@{data.addonTexts}"
+                                            android:textAppearance="@style/TextAppearance.AppCompat.Small"
+                                            android:textColor="@color/text_color"
+                                            android:textSize="@dimen/card_result_test_size_small"
+                                            android:visibility="@{data.addonTexts != null &amp;&amp; !&quot;null&quot;.equals(data.addonTexts) ? View.VISIBLE : View.GONE}"
+                                            tools:text="Workshop A\nLunch – Vegetarian" />
 
                                     </LinearLayout>
 

--- a/pretixscan/app/src/main/res/values-de/strings.xml
+++ b/pretixscan/app/src/main/res/values-de/strings.xml
@@ -205,4 +205,5 @@
     <string name="kiosk_error_printing_failed_timeout">Drucker Timeout</string>
     <string name="kiosk_error_unknown_scan_result_type">Unbekannter Scanergebnis Typus</string>
     <string name="reusable_media_exchange_nfc_needs_nfc_unknown">Der gescannte NFC-Chip wird von dieser pretixSCAN-Version nicht unterstützt</string>
+    <string name="addons_label">Add-ons:</string>
 </resources>

--- a/pretixscan/app/src/main/res/values/strings.xml
+++ b/pretixscan/app/src/main/res/values/strings.xml
@@ -206,4 +206,5 @@
     <string name="kiosk_error_unknown_scan_result_type">Unknown Scan Result Type</string>
     <string name="kiosk_text_noentry">No entry detected</string>
     <string name="kiosk_text_noentry_description">Your ticket will be valid again shortly</string>
+    <string name="addons_label">Add-ons:</string>
 </resources>


### PR DESCRIPTION
Displays the add-ons booked for a scanned ticket below the check-in texts on the result card.

needs: https://github.com/pretix/libpretixsync/pull/94


<img width="720" height="1280" alt="Screenshot_20260908_191623" src="https://github.com/user-attachments/assets/0710724c-dfd9-4767-ba44-fbc9701a61b7" />
